### PR TITLE
Add data field to ErrorResponse

### DIFF
--- a/packages/types/src/jsonrpc.ts
+++ b/packages/types/src/jsonrpc.ts
@@ -47,6 +47,7 @@ export interface JsonRpcError {
 export interface ErrorResponse {
   code: number;
   message: string;
+  data?: string;
 }
 
 export type JsonRpcResponse<T = any> = JsonRpcResult<T> | JsonRpcError;


### PR DESCRIPTION
I saw the data field returned from waku and couldn't access it on the relay. It isn't important but I just want to create a PR to keep track of it. https://www.jsonrpc.org/specification#error_object