### PR TITLE
Fix Infura incompatibility

### DIFF
--- a/packages/provider/src/http.ts
+++ b/packages/provider/src/http.ts
@@ -56,7 +56,7 @@ export class HttpConnection implements IJsonRpcConnection {
       this.api = await this.register();
     }
     this.api
-      .post("/", payload)
+      .post("", payload)
       .then(res => this.onPayload(res))
       .catch(err => this.onError(payload.id, err));
   }


### PR DESCRIPTION
When calling an an Infura RPC url with a trailing slash it returns a 401 error

```bash
curl https://ropsten.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161 \ 
-X POST \
-d '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}'

{"jsonrpc":"2.0","id":1,"result":"0xc14ec8"}
```
vs
```bash
curl https://ropsten.infura.io/v3/9aa3d95b3bc440fa88ea12eaa4456161/ \ 
-X POST \
-d '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}'

project id required in the url
```